### PR TITLE
fix typo in Rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ export default {
       sourcemap: true
     },
     {
-      file: 'dist/indes.es.js',
+      file: 'dist/index.es.js',
       format: 'es',
       exports: 'named',
       sourcemap: true


### PR DESCRIPTION
This corrects a slight typo in Rollup config that is breaking ES module usage